### PR TITLE
sugestão geral de alteração de texto

### DIFF
--- a/docs/traduzir-workshops.md
+++ b/docs/traduzir-workshops.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Traduzir Workshops
-description: 'Ajude a comunidade do HackClub Brasil'
+description: 'Ajude a comunidade do Hack Club Brasil'
 permalink: /traduzir-workshops/
 ---
 
@@ -31,7 +31,7 @@ Vá para seu terminal, crie um diretório novo com `mkdir "nome-do-diretorio"` .
 
 Ele vai demorar um tempo clonando o repositório, depois que o processo estiver acabado, vá para o diretório com `cd hackclubbjcentro_website`. E execute `gem install jekyll -v 3.9.0` para instalar o jekyll e `gem install bundler` para instalar o bundler.
 
-Com o bundler e o jekyll instalados, entre na pasta docs `cd /docs` e execute `bundle install` para instalar todas as dependências.
+Com o bundler e o jekyll instalados, entre na pasta docs com `cd docs` e execute `bundle install` para instalar todas as dependências.
 
 E a partir de agora você está pronto para começar.
 
@@ -100,6 +100,6 @@ Aqui vão algumas regras para a tradução:
 
 Depois que seu workshop estiver pronto para um líder de clube brasileiro usar no clube dele, abra um pull request e ele será analisado para depois ser colocado no site brasileiro do Hack Club.
 
-Beeeem, eu acho que é isso. Em caso de dúvidas, mande uma mensagem no Slack do Hack Club para mim. Sou o [@vitor](https://app.slack.com/client/T0266FRGM/CDJMS683D/user_profile/U018RDU68D9) e você também pode contar com o [@gabriel](https://app.slack.com/client/T0266FRGM/D01KABE85KK/user_profile/U01K3T48ZEG).
+Beeeem, eu acho que é isso. Em caso de dúvidas, mande uma mensagem para nosso time no Slack do Hack Club. Somos o grupo [@brasil](https://app.slack.com/client/T0266FRGM/browse-user-groups/user_groups/S01L1TL2RUY).
 
  :)

--- a/docs/traduzir-workshops.md
+++ b/docs/traduzir-workshops.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Traduzir Workshops
+description: 'Ajude a comunidade do HackClub Brasil'
 permalink: /traduzir-workshops/
 ---
 
@@ -8,9 +9,13 @@ permalink: /traduzir-workshops/
 
 <br/>
 
+
+Olá, ficamos muito felizes que você resolveu nos ajudar! Para traduzir os workshops é necessário conhecimento básico de [git](https://www.youtube.com/watch?v=IBClN6VpJDw&list=PLlAbYrWSYTiPA2iEiQ2PF_A9j__C4hi0A){:target="_blank"} e de [markdown](https://github.com/luong-komorebi/Markdown-Tutorial/blob/master/README_pt-BR.md){:target="_blank"}. Fica tranquilo que você pode contar com a gente. Se precisar é só perguntar [aqui](https://github.com/vitorvavolizza/hackclubbjcentro_website/issues/new){:target="_blank"}.
+
+
 ## Instalação do Projeto
 
-Vá para [https://github.com/vitorvavolizza/hackclubbjcentro_website](https://github.com/vitorvavolizza/hackclubbjcentro_website).
+Vá para [https://github.com/vitorvavolizza/hackclubbjcentro_website](https://github.com/vitorvavolizza/hackclubbjcentro_website){:target="_blank"}.
 
 E clique no botão verde `Code`.
 
@@ -26,7 +31,7 @@ Vá para seu terminal, crie um diretório novo com `mkdir "nome-do-diretorio"` .
 
 Ele vai demorar um tempo clonando o repositório, depois que o processo estiver acabado, vá para o diretório com `cd hackclubbjcentro_website`. E execute `gem install jekyll -v 3.9.0` para instalar o jekyll e `gem install bundler` para instalar o bundler.
 
-Com o bundler e o jekyll instalados, execute `bundle install` para instalar todas as dependências.
+Com o bundler e o jekyll instalados, entre na pasta docs `cd /docs` e execute `bundle install` para instalar todas as dependências.
 
 E a partir de agora você está pronto para começar.
 
@@ -95,7 +100,6 @@ Aqui vão algumas regras para a tradução:
 
 Depois que seu workshop estiver pronto para um líder de clube brasileiro usar no clube dele, abra um pull request e ele será analisado para depois ser colocado no site brasileiro do Hack Club.
 
-Beeeem, eu acho que é isso. Em caso de dúvidas, mande uma mensagem no Slack do Hack Club para mim. Sou o [@vitor](https://app.slack.com/client/T0266FRGM/CDJMS683D/user_profile/U018RDU68D9).
+Beeeem, eu acho que é isso. Em caso de dúvidas, mande uma mensagem no Slack do Hack Club para mim. Sou o [@vitor](https://app.slack.com/client/T0266FRGM/CDJMS683D/user_profile/U018RDU68D9) e você também pode contar com o [@gabriel](https://app.slack.com/client/T0266FRGM/D01KABE85KK/user_profile/U01K3T48ZEG).
 
  :)
-


### PR DESCRIPTION
nota: {:target="_blank"}. após um link funciona perfeitamente no site, mas aparentemente o github não entende bem. 
Solução:  Podemos fazer com  <a href="" target="_blank"> também.
recomendo fortemente a alteração da linha 34, por que se você tentar rodar o comando fora do diretório docs não funciona.